### PR TITLE
docs: update deprecated experimental_use_rmcp_client from Codex config.toml

### DIFF
--- a/documentation/docs/30-mcp/30-remote-setup.md
+++ b/documentation/docs/30-mcp/30-remote-setup.md
@@ -31,7 +31,7 @@ You can choose your preferred `scope` (it must be `user`, `project` or `local`) 
 Add the following to your `config.toml` (which defaults to `~/.codex/config.toml`, but refer to [the configuration documentation](https://github.com/openai/codex/blob/main/docs/config.md) for more advanced setups):
 
 ```toml
-experimental_use_rmcp_client = true
+rmcp_client = true
 [mcp_servers.svelte]
 url = "https://mcp.svelte.dev/mcp"
 ```


### PR DESCRIPTION
This PR follows the same observation as this ticket from Codex repo, dating november 20, 2025: [openai/codex#6995](https://github.com/openai/codex/issues/6995)

User [Sonaryr](https://github.com/Sonaryr):
"In the documentation and the CLI there is still a mention of `experimental_use_rmcp_client`.
While it still works, it is deprecated and should refer to  `[features].rmcp_client`"

This PR updates the docs to reflect that.
I just tested this config on my machine and Svelte remote MCP is recognized by Codex.

Tested in Codex:
```
 Model changed to gpt-5.6-luna low
› Do you have access to Svelte MCP ? Prove it quickly.
• I’ll query the Svelte documentation server now and show you the result.

• Called svelte.list-sections({})
  └ List of available Svelte documentation sections with their intended use cases. The "use_cases" field describes WHEN each section would be useful - analyze these carefully to determine which sections match
        the user's query:

    - title: Overview, use_cases: use title and path to estimate use case, path: ai/overview
    - title: AGENTS.md, use_cases: use title and path to estimate use case, path: ai/instructions
    - title: Overview, use_cases: use title and path to estimate use case, path: ai/mcp
    - title: Local setup, use_cases: use title and path to estimate use case, path: ai/local-setup
    - title: Remote setup, use_cases: use title and path to estimate use case, path: ai/remote-setup
    - title: Tools, use_cases: use title and path to estimate use case, path: ai/tools
    - title: Resources, use_cases: use title and path to estimate use case, path: ai/resources
    - title: Prompts, use_cases: use title and path to estimate use case, path: ai/prompts
    - title: CLI, use_cases: use title and path to estimate use case, path: ai/cli...

──────────────────────────────────────────────────

• Yes. I accessed the official Svelte MCP server and retrieved its complete documentation section index, including Svelte 5, SvelteKit, runes, routing, testing, and more.

──────────────────────────────────────────────────
```